### PR TITLE
Cosmopolitan Patches

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -20,7 +20,7 @@ jobs:
     - name: cosmocc
       env:
           FEATURES: cli
-          CC: cosmocc -mclang
+          CC: cosmocc
           CXX: cosmoc++
           PLATFORM: cosmo
       run: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -22,5 +22,6 @@ jobs:
     - name: cosmocc
       env:
           CC: cosmocc
+          FEATURES: cli
       run: make
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         # Cosmopolitan release version
         # Default: latest
-        version: ""
+        version: "latest"
     - name: make
       run: make
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,10 +17,6 @@ jobs:
     - uses: bjia56/setup-cosmocc@main
       with:
         version: "latest"
-        
-    - name: gcc make
-      run: make
-
     - name: cosmocc
       env:
           FEATURES: cli

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -24,7 +24,7 @@ jobs:
     - name: cosmocc
       env:
           FEATURES: cli
-          CC: cosmocc
+          CC: cosmocc -mclang
           CXX: cosmoc++
       run: make
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,11 +17,14 @@ jobs:
     - uses: bjia56/setup-cosmocc@main
       with:
         version: "latest"
+        
     - name: gcc make
       run: make
+
     - name: cosmocc
       env:
-          CC: cosmocc
           FEATURES: cli
+          CC: cosmocc
+          CXX: cosmoc++
       run: make
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -26,5 +26,6 @@ jobs:
           FEATURES: cli
           CC: cosmocc -mclang
           CXX: cosmoc++
+          PLATFORM: cosmo
       run: make
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,24 @@
+name: C/C++ CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: bjia56/setup-cosmocc@main
+      with:
+        # Cosmopolitan release version
+        # Default: latest
+        version: ""
+    - name: make
+      run: make
+

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,9 +16,11 @@ jobs:
     - uses: actions/checkout@v4
     - uses: bjia56/setup-cosmocc@main
       with:
-        # Cosmopolitan release version
-        # Default: latest
         version: "latest"
-    - name: make
+    - name: gcc make
+      run: make
+    - name: cosmocc
+      env:
+          CC: cosmocc
       run: make
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Cosmo Releaser
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,12 @@ jobs:
     - uses: bjia56/setup-cosmocc@main
       with:
         version: "latest"
-    - name: make
-      run: make
+    - name: cosmocc
+      env:
+          FEATURES: cli
+          CC: cosmocc
+          CXX: cosmoc++
+          PLATFORM: cosmo
     - name: Upload release
       if: github.event_name != 'pull_request'
       uses: boxpositron/upload-multiple-releases@1.0.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: C/C++ CI
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: bjia56/setup-cosmocc@main
+      with:
+        version: "latest"
+    - name: make
+      run: make
+    - name: Upload release
+      if: github.event_name != 'pull_request'
+      uses: boxpositron/upload-multiple-releases@1.0.7
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_config: |
+            build/dhtd
+        tag_name: ${{ github.ref_name }}
+        release_name: dhtd_cosmopolitan
+        draft: false
+        prerelease: false
+        overwrite: true   

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc 
 ifneq (,$(findstring cosmocc,$(CC)))
-    CFLAGS += -mclang -static -nostdlib -fno-pie -mno-red-zone -Wno-implicit-function-declaration
+    CFLAGS += -mclang -static -Wall -Wwrite-strings -pedantic -std=gnu99 -Wno-implicit-function-declaration
 else
     CFLAGS += -Wall -Wwrite-strings -pedantic -std=gnu99
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc 
 ifneq (,$(findstring cosmocc,$(CC)))
-    CFLAGS += -mclang -static -Wall -Wwrite-strings -pedantic -std=gnu99 -Wno-implicit-function-declaration
+    CFLAGS += -mclang -static -Wall -Wwrite-strings -pedantic -std=gnu99 -Wno-implicit-function-declaration -DAF_INET6=10
 else
     CFLAGS += -Wall -Wwrite-strings -pedantic -std=gnu99
 endif

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ else
 endif
 
 LDFLAGS += -lc
-FEATURES ?= cli lpd debug
+# FEATURES ?= cli lpd debug
+FEATURES ?= cli
 
 OBJS = build/kad.o build/log.o build/results.o \
 	build/conf.o build/net.o build/utils.o \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc 
-ifeq ($(CC),cosmocc)
-    CFLAGS += -static -nostdlib -fno-pie -mno-red-zone -Wno-implicit-function-declaration -mclang
+ifneq (,$(findstring cosmocc,$(CC)))
+    CFLAGS += -mclang -static -nostdlib -fno-pie -mno-red-zone -Wno-implicit-function-declaration
 else
     CFLAGS += -Wall -Wwrite-strings -pedantic -std=gnu99
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+CC ?= gcc 
+ifeq ($(CC),cosmocc)
+    CFLAGS += -static -nostdlib -fno-pie -mno-red-zone -Wno-implicit-function-declaration -mclang
+else
+    CFLAGS += -Wall -Wwrite-strings -pedantic -std=gnu99
+endif
 
-CFLAGS += -Wall -Wwrite-strings -pedantic -std=gnu99
 LDFLAGS += -lc
 FEATURES ?= cli lpd debug
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc 
 ifneq (,$(findstring cosmocc,$(CC)))
-    CFLAGS += -mclang -static -Wall -Wwrite-strings -pedantic -std=gnu99 -Wno-implicit-function-declaration -DAF_INET6=10
+    CFLAGS += -mclang -static -Wall -Wwrite-strings
 else
     CFLAGS += -Wall -Wwrite-strings -pedantic -std=gnu99
 endif

--- a/src/dht.c
+++ b/src/dht.c
@@ -63,6 +63,11 @@ THE SOFTWARE.
 #endif
 
 #include "dht.h"
+#if defined(AF_INET6)
+    #define AF_INET6_CONST AF_INET6
+#else
+    #define AF_INET6_CONST 0
+#endif
 
 #ifndef HAVE_MEMMEM
 #ifdef __GLIBC__
@@ -84,12 +89,6 @@ extern int dht_gettimeofday(struct timeval *tv, struct timezone *tz);
 
 #undef EAFNOSUPPORT
 #define EAFNOSUPPORT WSAEAFNOSUPPORT
-
-#if defined(AF_INET6)
-    #define AF_INET6_CONST AF_INET6
-#else
-    #define AF_INET6_CONST 0
-#endif
 
 static int
 random(void)

--- a/src/dht.c
+++ b/src/dht.c
@@ -63,11 +63,6 @@ THE SOFTWARE.
 #endif
 
 #include "dht.h"
-#if defined(AF_INET6)
-    #define AF_INET6_CONST AF_INET6
-#else
-    #define AF_INET6_CONST 0
-#endif
 
 #ifndef HAVE_MEMMEM
 #ifdef __GLIBC__
@@ -395,7 +390,7 @@ is_martian(const struct sockaddr *sa)
             (address[0] == 127) ||
             ((address[0] & 0xE0) == 0xE0);
     }
-    case AF_INET6_CONST: {
+    case AF_INET6: {
         struct sockaddr_in6 *sin6 = (struct sockaddr_in6*)sa;
         const unsigned char *address = (const unsigned char*)&sin6->sin6_addr;
         return sin6->sin6_port == 0 ||
@@ -2268,7 +2263,7 @@ dht_periodic(const void *buf, size_t buflen,
                 case AF_INET:
                     m.port = htons(((struct sockaddr_in*)from)->sin_port);
                     break;
-                case AF_INET6_CONST:
+                case AF_INET6:
                     m.port = htons(((struct sockaddr_in6*)from)->sin6_port);
                     break;
                 }

--- a/src/dht.c
+++ b/src/dht.c
@@ -2269,7 +2269,7 @@ dht_periodic(const void *buf, size_t buflen,
                 case AF_INET:
                     m.port = htons(((struct sockaddr_in*)from)->sin_port);
                     break;
-                case AF_INET6:
+                case AF_INET6_CONST:
                     m.port = htons(((struct sockaddr_in6*)from)->sin6_port);
                     break;
                 }

--- a/src/dht.c
+++ b/src/dht.c
@@ -378,6 +378,12 @@ print_hex(FILE *f, const unsigned char *buf, int buflen)
         fprintf(f, "%02x", buf[i]);
 }
 
+#ifndef AF_INET6_CONST
+    #define AF_INET6_CONST 10  // Standard value for IPv6
+#else
+    #define AF_INET6_CONST AF_INET6  // Use the system's AF_INET6 directly
+#endif
+
 static int
 is_martian(const struct sockaddr *sa)
 {
@@ -390,7 +396,7 @@ is_martian(const struct sockaddr *sa)
             (address[0] == 127) ||
             ((address[0] & 0xE0) == 0xE0);
     }
-    case AF_INET6: {
+    case AF_INET6_CONST: {
         struct sockaddr_in6 *sin6 = (struct sockaddr_in6*)sa;
         const unsigned char *address = (const unsigned char*)&sin6->sin6_addr;
         return sin6->sin6_port == 0 ||

--- a/src/dht.c
+++ b/src/dht.c
@@ -85,6 +85,12 @@ extern int dht_gettimeofday(struct timeval *tv, struct timezone *tz);
 #undef EAFNOSUPPORT
 #define EAFNOSUPPORT WSAEAFNOSUPPORT
 
+#if defined(AF_INET6)
+    #define AF_INET6_CONST AF_INET6
+#else
+    #define AF_INET6_CONST 0
+#endif
+
 static int
 random(void)
 {
@@ -390,7 +396,7 @@ is_martian(const struct sockaddr *sa)
             (address[0] == 127) ||
             ((address[0] & 0xE0) == 0xE0);
     }
-    case AF_INET6: {
+    case AF_INET6_CONST: {
         struct sockaddr_in6 *sin6 = (struct sockaddr_in6*)sa;
         const unsigned char *address = (const unsigned char*)&sin6->sin6_addr;
         return sin6->sin6_port == 0 ||
@@ -2263,7 +2269,7 @@ dht_periodic(const void *buf, size_t buflen,
                 case AF_INET:
                     m.port = htons(((struct sockaddr_in*)from)->sin_port);
                     break;
-                case AF_INET6:
+                case AF_INET6_CONST:
                     m.port = htons(((struct sockaddr_in6*)from)->sin6_port);
                     break;
                 }

--- a/src/dht.c
+++ b/src/dht.c
@@ -103,17 +103,9 @@ extern const char *inet_ntop(int, const void *, char *, socklen_t);
 
 #endif
 
-#ifndef AF_INET
-#error "AF_INET not defined; required for IPv4 support"
-#endif
-
-#ifndef AF_INET6
-#error "AF_INET6 not defined; required for IPv6 support"
-#endif
-
 /* We set sin_family to 0 to mark unused slots. */
 #if AF_INET == 0 || AF_INET6 == 0
-/* Skip #error You lose */ 
+#error You lose */ 
 #endif
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L

--- a/src/dht.c
+++ b/src/dht.c
@@ -105,7 +105,7 @@ extern const char *inet_ntop(int, const void *, char *, socklen_t);
 
 /* We set sin_family to 0 to mark unused slots. */
 #if AF_INET == 0 || AF_INET6 == 0
-#error You lose */ 
+/* #error You lose */
 #endif
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L

--- a/src/dht.c
+++ b/src/dht.c
@@ -103,9 +103,17 @@ extern const char *inet_ntop(int, const void *, char *, socklen_t);
 
 #endif
 
+#ifndef AF_INET
+#error "AF_INET not defined; required for IPv4 support"
+#endif
+
+#ifndef AF_INET6
+#error "AF_INET6 not defined; required for IPv6 support"
+#endif
+
 /* We set sin_family to 0 to mark unused slots. */
 #if AF_INET == 0 || AF_INET6 == 0
-#error You lose
+/* Skip #error You lose */ 
 #endif
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L

--- a/src/net.c
+++ b/src/net.c
@@ -20,6 +20,9 @@
 #include "utils.h"
 #include "net.h"
 
+#ifndef SO_BINDTODEVICE
+    #define SO_BINDTODEVICE false
+#endif
 
 static struct pollfd g_fds[16] = { 0 };
 static net_callback* g_cbs[16] = { NULL };

--- a/src/results.c
+++ b/src/results.c
@@ -19,6 +19,12 @@
 * Therefore, results are collected and stored here.
 */
 
+#ifndef AF_INET6_CONST
+    #define AF_INET6_CONST 10  // Standard value for IPv6 (adjust if needed)
+#else
+    #define AF_INET6_CONST AF_INET6  // Use the system's AF_INET6 directly
+#endif
+
 struct result_t {
     uint8_t ip[16];
     uint8_t length;
@@ -142,7 +148,7 @@ void results_add(const uint8_t id[], int af, const void *data, size_t data_len)
             }
             break;
         }
-        case AF_INET6: {
+        case AF_INET6_CONST: {
             size_t got = (data_len / sizeof(struct dht_addr6_t));
             size_t add = MIN(got, search->maxresults - numresults);
             struct dht_addr6_t *data6 = (struct dht_addr6_t *) data;
@@ -158,7 +164,7 @@ unsigned results_count(const uint8_t id[], int af)
     struct search_t *search = find_search(id);
     if (search) switch (af) {
         case AF_INET: return search->numresults4;
-        case AF_INET6: return search->numresults6;
+        case AF_INET6_CONST: return search->numresults6;
         default: return search->numresults4 + search->numresults6;
     }
     return 0;

--- a/src/utils.c
+++ b/src/utils.c
@@ -16,6 +16,11 @@
 #include "conf.h"
 #include "utils.h"
 
+#ifndef AF_INET6_CONST
+    #define AF_INET6_CONST 10  // Standard value for IPv6 (adjust if needed)
+#else
+    #define AF_INET6_CONST AF_INET6  // Use the system's AF_INET6 directly
+#endif
 
 // separate a string into a list of arguments (int argc, char **argv)
 int setargs(const char **argv, int argv_size, char *args)
@@ -227,7 +232,7 @@ bool port_set(IP *addr, uint16_t port)
     case AF_INET:
         ((IP4 *)addr)->sin_port = htons(port);
         return true;
-    case AF_INET6:
+    case AF_INET6_CONST:
         ((IP6 *)addr)->sin6_port = htons(port);
         return true;
     default:
@@ -266,7 +271,7 @@ const char *str_af(int af) {
     switch (af) {
     case AF_INET:
         return "IPv4";
-    case AF_INET6:
+    case AF_INET6_CONST:
         return "IPv6";
     case AF_UNSPEC:
         return "IPv4+IPv6";
@@ -302,7 +307,7 @@ const char *str_addr2(const void *ip, uint8_t length, uint16_t port)
 const char *str_addr(const IP *addr)
 {
     switch (addr->ss_family) {
-    case AF_INET6: {
+    case AF_INET6_CONST: {
         uint16_t port = ntohs(((IP6 *)addr)->sin6_port);
         return str_addr2(&((IP6 *)addr)->sin6_addr, 16, port);
     }
@@ -323,7 +328,7 @@ bool addr_is_localhost(const IP *addr)
     switch (addr->ss_family) {
     case AF_INET:
         return (memcmp(&((IP4 *)addr)->sin_addr, &inaddr_loopback, 4) == 0);
-    case AF_INET6:
+    case AF_INET6_CONST:
         return (memcmp(&((IP6 *)addr)->sin6_addr, &in6addr_loopback, 16) == 0);
     default:
         return false;
@@ -335,7 +340,7 @@ bool addr_is_multicast(const IP *addr)
     switch (addr->ss_family) {
     case AF_INET:
         return IN_MULTICAST(ntohl(((IP4*) addr)->sin_addr.s_addr));
-    case AF_INET6:
+    case AF_INET6_CONST:
         return IN6_IS_ADDR_MULTICAST(&((IP6*) addr)->sin6_addr);
     default:
         return false;
@@ -347,7 +352,7 @@ int addr_port(const IP *addr)
     switch (addr->ss_family) {
     case AF_INET:
         return ntohs(((IP4 *)addr)->sin_port);
-    case AF_INET6:
+    case AF_INET6_CONST:
         return ntohs(((IP6 *)addr)->sin6_port);
     default:
         return 0;
@@ -359,7 +364,7 @@ int addr_len(const IP *addr)
     switch (addr->ss_family) {
     case AF_INET:
         return sizeof(IP4);
-    case AF_INET6:
+    case AF_INET6_CONST:
         return sizeof(IP6);
     default:
         return 0;


### PR DESCRIPTION
### Cosmocc

Various experimental (as in ugly) patches to compile dhtd using cosmocc/cosmopolitan

### Limits 

- no background mode supported
- In Cosmopolitan, `AF_INET6` (and potentially other AF_* constants) are defined as `const int` variables, not as `integer constants`